### PR TITLE
Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module "stackset" {
 | Name | Type |
 |------|------|
 | [aws_cloudformation_stack_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set.self_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
 | [aws_cloudformation_stack_set_instance.accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_cloudformation_stack_set_instance.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 
@@ -106,5 +107,5 @@ Checkout our other :point\_right: [terraform modules](https://registry.terraform
 
 ## Copyright
 
-Copyright © 2017-2024 [Blackbird Cloud](https://blackbird.cloud)
+Copyright © 2017-2025 [Blackbird Cloud](https://blackbird.cloud)
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudformation_stack_set" "default" {
+  count = var.permission_model == "SERVICE_MANAGED" ? 1 : 0
+
   name        = var.name
   description = var.description
   tags        = var.tags
@@ -33,7 +35,52 @@ resource "aws_cloudformation_stack_set" "default" {
   template_url  = var.template_url
 
   lifecycle {
-    ignore_changes = var.stack_set_ignore_changes
+    ignore_changes = [
+      administration_role_arn,
+    ]
+  }
+}
+
+resource "aws_cloudformation_stack_set" "self_managed" {
+  count = var.permission_model == "SELF_MANAGED" ? 1 : 0
+
+  name        = var.name
+  description = var.description
+  tags        = var.tags
+
+  permission_model = var.permission_model
+  call_as          = var.call_as
+
+  execution_role_name     = var.execution_role_name
+  administration_role_arn = var.administration_role_arn
+
+  capabilities = var.capabilities
+  parameters   = var.parameters
+
+  dynamic "auto_deployment" {
+    for_each = var.auto_deployment.enabled ? [1] : []
+    content {
+      retain_stacks_on_account_removal = var.auto_deployment.retain_stacks_on_account_removal
+      enabled                          = var.auto_deployment.enabled
+    }
+  }
+
+  operation_preferences {
+    failure_tolerance_count      = try(var.operation_preferences.failure_tolerance_count, null)
+    failure_tolerance_percentage = try(var.operation_preferences.failure_tolerance_percentage, null)
+    max_concurrent_count         = try(var.operation_preferences.max_concurrent_count, null)
+    max_concurrent_percentage    = try(var.operation_preferences.max_concurrent_percentage, null)
+    region_concurrency_type      = try(var.operation_preferences.region_concurrency_type, null)
+    region_order                 = try(var.operation_preferences.region_order, null)
+  }
+
+  template_body = var.template_body
+  template_url  = var.template_url
+
+  lifecycle {
+    ignore_changes = [
+      administration_role_arn,
+    ]
   }
 }
 
@@ -54,11 +101,15 @@ resource "aws_cloudformation_stack_set_instance" "default" {
     region_order                 = try(var.operation_preferences.region_order, null)
   }
 
-  retain_stack   = var.stackset_instance_retain_stack
-  call_as        = var.stackset_instance_call_as
-  region         = var.stackset_instance_region
-  account_id     = var.stackset_instance_account_id
-  stack_set_name = aws_cloudformation_stack_set.default.name
+  retain_stack = var.stackset_instance_retain_stack
+  call_as      = var.stackset_instance_call_as
+  region       = var.stackset_instance_region
+  account_id   = var.stackset_instance_account_id
+  stack_set_name = (
+    var.permission_model == "SERVICE_MANAGED"
+    ? aws_cloudformation_stack_set.default[0].name
+    : aws_cloudformation_stack_set.self_managed[0].name
+  )
 }
 
 resource "aws_cloudformation_stack_set_instance" "accounts" {
@@ -78,9 +129,13 @@ resource "aws_cloudformation_stack_set_instance" "accounts" {
     region_order                 = try(var.operation_preferences.region_order, null)
   }
 
-  retain_stack   = var.stackset_instance_retain_stack
-  call_as        = var.stackset_instance_call_as
-  region         = var.stackset_instance_region
-  account_id     = var.stackset_instance_account_id
-  stack_set_name = aws_cloudformation_stack_set.default.name
+  retain_stack = var.stackset_instance_retain_stack
+  call_as      = var.stackset_instance_call_as
+  region       = var.stackset_instance_region
+  account_id   = var.stackset_instance_account_id
+  stack_set_name = (
+    var.permission_model == "SERVICE_MANAGED"
+    ? aws_cloudformation_stack_set.default[0].name
+    : aws_cloudformation_stack_set.self_managed[0].name
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,10 @@ resource "aws_cloudformation_stack_set" "default" {
 
   template_body = var.template_body
   template_url  = var.template_url
+
+  lifecycle {
+    ignore_changes = var.stack_set_ignore_changes
+  }
 }
 
 resource "aws_cloudformation_stack_set_instance" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,9 @@
 output "stackset" {
-  value       = aws_cloudformation_stack_set.default
+  value       = (
+    var.permission_model == "SERVICE_MANAGED"
+    ? aws_cloudformation_stack_set.default[0]
+    : aws_cloudformation_stack_set.self_managed[0]
+  )
   description = "The AWS Cloudformation StackSet."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -129,9 +129,3 @@ variable "stackset_instance_accounts" {
   description = "The list of AWS Account IDs to which StackSets instance deploys."
   default     = []
 }
-
-variable "stack_set_ignore_changes" {
-  type        = list(string)
-  description = "(Optional) A list of attributes to ignore changes to. This is useful for attributes that are managed outside of Terraform, such as the administration_role_arn."
-  default     = [administration_role_arn]
-}

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "stackset_instance_accounts" {
   description = "The list of AWS Account IDs to which StackSets instance deploys."
   default     = []
 }
+
+variable "stack_set_ignore_changes" {
+  type        = list(string)
+  description = "(Optional) A list of attributes to ignore changes to. This is useful for attributes that are managed outside of Terraform, such as the administration_role_arn."
+  default     = [administration_role_arn]
+}


### PR DESCRIPTION
## What
* Use a different resource with `lifecycle` when `permission_model = "SELF_MANAGED"`

## Why
* When `permission_model = "SELF_MANAGED"` the role arn is not managed and it always trigger changes.

See this issue on [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/23464).

