### PR TITLE
The deployments_targets in aws has changed.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,38 +85,10 @@ resource "aws_cloudformation_stack_set" "self_managed" {
 }
 
 resource "aws_cloudformation_stack_set_instance" "this" {
-  for_each = var.create_instance && length(var.stackset_instance_organizational_unit_ids) > 0 ? toset(var.stackset_instance_organizational_unit_ids) : toset([])
-
   deployment_targets {
-    organizational_unit_ids = [each.key]
-  }
-
-  operation_preferences {
-    failure_tolerance_count      = try(var.operation_preferences.failure_tolerance_count, null)
-    failure_tolerance_percentage = try(var.operation_preferences.failure_tolerance_percentage, null)
-    max_concurrent_count         = try(var.operation_preferences.max_concurrent_count, null)
-    max_concurrent_percentage    = try(var.operation_preferences.max_concurrent_percentage, null)
-    concurrency_mode             = try(var.operation_preferences.concurrency_mode, null)
-    region_concurrency_type      = try(var.operation_preferences.region_concurrency_type, null)
-    region_order                 = try(var.operation_preferences.region_order, null)
-  }
-
-  retain_stack = var.stackset_instance_retain_stack
-  call_as      = var.stackset_instance_call_as
-  region       = var.stackset_instance_region
-  account_id   = var.stackset_instance_account_id
-  stack_set_name = (
-    var.permission_model == "SERVICE_MANAGED"
-    ? aws_cloudformation_stack_set.default[0].name
-    : aws_cloudformation_stack_set.self_managed[0].name
-  )
-}
-
-resource "aws_cloudformation_stack_set_instance" "accounts" {
-  count = var.create_instance == true && length(var.stackset_instance_accounts) > 0 ? 1 : 0
-
-  deployment_targets {
+    organizational_unit_ids = var.stackset_instance_organizational_unit_ids
     accounts = var.stackset_instance_accounts
+    account_filter_type = try(var.stackset_instance_account_filter_type, null)
   }
 
   operation_preferences {

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,8 @@ variable "stackset_instance_accounts" {
   description = "The list of AWS Account IDs to which StackSets instance deploys."
   default     = []
 }
+variable "stackset_instance_account_filter_type" {
+  type        = string
+  description = "(Optional) The filter type to use when specifying accounts for StackSets instance deploys. Valid values: NONE, INTERSECTION, DIFFERENCE, UNION."
+  default     = null
+}


### PR DESCRIPTION
When used no var.stackset_instance_organizational_unit_ids:
```
  │ Error: Invalid function argument
  │
  │   on main.tf line 88, in resource "aws_cloudformation_stack_set_instance" "this":
  │   88:   for_each = var.create_instance && length(var.stackset_instance_organizational_unit_ids) > 0 ? toset(var.stackset_instance_organizational_unit_ids) : toset([])
  │     ├────────────────
  │     │ while calling length(value)
  │     │ var.stackset_instance_organizational_unit_ids is null
  │
  │ Invalid value for "value" parameter: argument must not be null.
```

When used [] as value for var.stackset_instance_organizational_unit_ids:
`  | Error: creating CloudFormation StackSet Instance: operation error CloudFormation: CreateStackInstances, https response error StatusCode: 400, RequestID: xyz, api error ValidationError: OrganizationalUnitIds are required`

So reworked the module to how it should be used now.




**Note this is a breaking change!!!**
The for loop in the aws_cloudformation_stack_set_instance is removed.